### PR TITLE
Replace deprecated create_function calls

### DIFF
--- a/include/display_collections.inc.php
+++ b/include/display_collections.inc.php
@@ -67,7 +67,7 @@ if ($page['total_categories'])
 // collections details
 if ($page['total_categories'])
 {
-  $categories_id = array_map(create_function('$c', 'return $c["id"];'), $categories);
+  $categories_id = array_column($categories, 'id');
 
   $query = '
 SELECT * FROM (

--- a/include/display_collections.inc.php
+++ b/include/display_collections.inc.php
@@ -67,7 +67,10 @@ if ($page['total_categories'])
 // collections details
 if ($page['total_categories'])
 {
-  $categories_id = array_column($categories, 'id');
+  $categories_id = array();
+  foreach ($categories as $category) {
+      $category_id[] = $category['id'];
+  }
 
   $query = '
 SELECT * FROM (

--- a/include/events.inc.php
+++ b/include/events.inc.php
@@ -91,7 +91,7 @@ function user_collections_thumbnails_list($tpl_thumbnails_var, $pictures)
     return $tpl_thumbnails_var;
   }
 
-  $image_ids = array_map(create_function('$i', 'return $i["id"];'), $pictures);
+  $image_ids = array_column($pictures, 'id');
 
   // get collections for each picture
   $query = '

--- a/include/events.inc.php
+++ b/include/events.inc.php
@@ -91,7 +91,10 @@ function user_collections_thumbnails_list($tpl_thumbnails_var, $pictures)
     return $tpl_thumbnails_var;
   }
 
-  $image_ids = array_column($pictures, 'id');
+  $image_ids = array();
+  foreach ($pictures as $picture) {
+      $image_ids[] = $picture['id'];
+  }
 
   // get collections for each picture
   $query = '


### PR DESCRIPTION
`create_function` is deprecated in PHP 7.2 and can be easily replace by anonymous functions. But in this case `array_column` does exactly what was intended.